### PR TITLE
Add min-height styles for layout consistency in PostInfo and BlogPost components

### DIFF
--- a/src/components/widgets/PostInfo.astro
+++ b/src/components/widgets/PostInfo.astro
@@ -17,6 +17,7 @@ const { pubDate, modDate = undefined, readTime = undefined, classNames = undefin
     'flex flex-wrap gap-x-1 gap-y-1 text-xs md:text-sm text-opacity-50 min-h-[2rem] md:min-h-[2.5rem] items-center justify-center',
     classNames && classNames
   ]}
+  style='min-height: 2rem;'
 >
   <p class='whitespace-nowrap'>初稿:<FormattedDate date={pubDate} /></p>
   {

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -38,7 +38,7 @@ const { title, description, pubDate, modDate, heroImage = null, tags } = data
   <article class='min-w-full sm:max-w-none md:max-w-none md:py-4'>
     <header class='mb-3 flex flex-col items-center justify-center gap-4'>
       <div class='flex flex-col'>
-        <h1 class='text-balancetext-center text-3xl font-semibold'>
+        <h1 class='text-balancetext-center text-3xl font-semibold' style='min-height: 3rem;'>
           {title}
         </h1>
         {
@@ -52,7 +52,7 @@ const { title, description, pubDate, modDate, heroImage = null, tags } = data
           )
         }
       </div>
-      <div class='flex flex-wrap items-center justify-center gap-3'>
+      <div class='flex flex-wrap items-center justify-center gap-3' style='min-height: 2rem;'>
         {tags.map((tag: string) => <Tag tag={tag} />)}
       </div>
     </header>


### PR DESCRIPTION
Introduce min-height styles to enhance the layout consistency of the PostInfo and BlogPost components.